### PR TITLE
Implement backoff utilities.

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -41,7 +41,7 @@ type Backoff struct {
 	// with Max it is used to produce the "bounded wait duration".
 	Min time.Duration
 
-	// Min is an upper bound for the "transformed wait duration", in combination
+	// Max is an upper bound for the "transformed wait duration", in combination
 	// with Min it is used to produce the "bounded wait duration".
 	Max time.Duration
 

--- a/backoff.go
+++ b/backoff.go
@@ -23,8 +23,8 @@ type BackoffStrategy func(n int, err error) time.Duration
 // that the operation is expensive.
 var DefaultBackoffStrategy BackoffStrategy = ExponentialBackoff(3 * time.Second)
 
-// Backoff introduces delays between atempts to perform some application-defined
-// operation.
+// Backoff introduces delays between attempts to perform some
+// application-defined operation.
 type Backoff struct {
 	// Strategy is the backoff strategy used to compute the "fundamental wait
 	// duration". If it is nil, DefaultBackoffStrategy is used.
@@ -41,7 +41,7 @@ type Backoff struct {
 	// with Max it is used to produce the "bounded wait duration".
 	Min time.Duration
 
-	// Min is a upper bound for the "transformed wait duration", in combination
+	// Min is an upper bound for the "transformed wait duration", in combination
 	// with Min it is used to produce the "bounded wait duration".
 	Max time.Duration
 
@@ -82,8 +82,8 @@ func (b *Backoff) Fail(err error) time.Duration {
 	return d
 }
 
-// Sleep marks the most recent attempt and pauses the current goroutine until
-// the "bounded wait duration" has elapsed.
+// Sleep marks the most recent attempt as a failure and pauses the current
+// goroutine until the "bounded wait duration" has elapsed.
 //
 // It sleeps until the duration elapses or ctx is canceled, whichever is first.
 // If ctx is canceled before the duration elapses it returns ctx.Err(),

--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,132 @@
+package linger
+
+import (
+	"context"
+	"math"
+	"sync/atomic"
+	"time"
+)
+
+// BackoffStrategy is a function for computing delays between attempts to
+// perform some application-defined operation.
+//
+// n is the number of successive failures since the last success, including this
+// one.
+//
+// err is the error describing the operation's failure, if known. A nil error
+// does not indicate a success.
+type BackoffStrategy func(n int, err error) time.Duration
+
+// DefaultBackoffStrategy is the default strategy used by Backoff.
+//
+// It is a conservative policy favouring large delay times under the assumption
+// that the operation is expensive.
+var DefaultBackoffStrategy BackoffStrategy = ExponentialBackoff(3 * time.Second)
+
+// Backoff introduces delays between atempts to perform some application-defined
+// operation.
+type Backoff struct {
+	// Strategy is the backoff strategy used to compute the "fundamental wait
+	// duration". If it is nil, DefaultBackoffStrategy is used.
+	Strategy BackoffStrategy
+
+	// Transform is applied to the "fundamental wait duration" to produce the
+	// "transformed wait duration".
+	//
+	// If it is nil, FullJitter is used. The Identity transform can be used to
+	// disable the transform.
+	Transform DurationTransform
+
+	// Min is a lower bound for the "transformed wait duration", in combination
+	// with Max it is used to produce the "bounded wait duration".
+	Min time.Duration
+
+	// Min is a upper bound for the "transformed wait duration", in combination
+	// with Min it is used to produce the "bounded wait duration".
+	Max time.Duration
+
+	// failures is the number of successive failures that have occurred.
+	failures uint32
+}
+
+// Ok marks the most recent attempt as a success.
+func (b *Backoff) Ok() {
+	atomic.StoreUint32(&b.failures, 0)
+}
+
+// Fail marks the most recent attempt as a failure and returns the "bounded wait
+// duration", which is the time to wait before retrying the operation.
+//
+// err is the error describing the operation's failure, if known. A nil error
+// does not indicate a success.
+func (b *Backoff) Fail(err error) time.Duration {
+	min := Longest(b.Min, 0)
+	max := MustCoalesce(b.Max, 1*time.Hour)
+
+	strategy := b.Strategy
+	if strategy == nil {
+		strategy = DefaultBackoffStrategy
+	}
+
+	transform := b.Transform
+	if transform == nil {
+		transform = FullJitter
+	}
+
+	n := atomic.AddUint32(&b.failures, 1)
+
+	d := strategy(int(n), err) // fundamental
+	d = transform(d)           // transformed
+	d = Limit(d, min, max)     // bounded
+
+	return d
+}
+
+// Sleep marks the most recent attempt and pauses the current goroutine until
+// the "bounded wait duration" has elapsed.
+//
+// It sleeps until the duration elapses or ctx is canceled, whichever is first.
+// If ctx is canceled before the duration elapses it returns ctx.Err(),
+// otherwise it returns nil.
+//
+// err is the error describing the operation's failure, if known. A nil error
+// does not indicate a success.
+func (b *Backoff) Sleep(ctx context.Context, err error) error {
+	return Sleep(ctx, b.Fail(err))
+}
+
+// ExponentialBackoff returns a BackoffStrategy that uses binary exponential
+// backoff (BEB).
+//
+// The unit delay is doubled after each successive failure.
+func ExponentialBackoff(unit time.Duration) BackoffStrategy {
+	if unit <= 0 {
+		panic("the unit duration must be postive")
+	}
+
+	u := unit.Seconds()
+
+	return func(n int, _ error) time.Duration {
+		scale := math.Pow(2, float64(n-1))
+		seconds := u * scale
+
+		return FromSeconds(seconds)
+	}
+}
+
+// ConstantBackoff returns a BackoffStrategy that returns a fixed wait duration.
+func ConstantBackoff(d time.Duration) BackoffStrategy {
+	return func(_ int, _ error) time.Duration {
+		return d
+	}
+}
+
+// LinearBackoff returns a BackoffStrategy that increases the wait duration
+// linearly.
+//
+// The unit delay is multiplied by the number of successive failures.
+func LinearBackoff(unit time.Duration) BackoffStrategy {
+	return func(n int, _ error) time.Duration {
+		return time.Duration(n) * unit
+	}
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -1,0 +1,169 @@
+package linger
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Backoff", func() {
+	var backoff *Backoff
+
+	BeforeEach(func() {
+		backoff = &Backoff{
+			Strategy:  LinearBackoff(10 * time.Millisecond),
+			Transform: Identity,
+		}
+	})
+
+	Describe("func Ok()", func() {
+		It("resets the failure count", func() {
+			backoff.Fail(nil)
+			backoff.Fail(nil)
+			backoff.Ok()
+
+			Expect(backoff.Fail(nil)).To(Equal(10 * time.Millisecond))
+		})
+	})
+
+	Describe("func Fail()", func() {
+		It("uses the backoff strategy", func() {
+			Expect(backoff.Fail(nil)).To(Equal(10 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(20 * time.Millisecond))
+		})
+
+		It("uses the default backoff strategy if none is specified", func() {
+			backoff.Strategy = nil
+
+			Expect(backoff.Fail(nil)).To(Equal(3 * time.Second))
+			Expect(backoff.Fail(nil)).To(Equal(6 * time.Second))
+			Expect(backoff.Fail(nil)).To(Equal(12 * time.Second))
+		})
+
+		It("applies the transform", func() {
+			backoff.Transform = func(d time.Duration) time.Duration {
+				return d * 2
+			}
+
+			Expect(backoff.Fail(nil)).To(Equal(20 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(40 * time.Millisecond))
+		})
+
+		It("uses a full-jitter transform by default", func() {
+			backoff.Transform = nil
+
+			for attempts := 0; attempts < 10000; attempts++ {
+				backoff.Ok()
+
+				d := backoff.Fail(nil)
+				Expect(d).To(BeNumerically(">=", 0*time.Millisecond))
+				Expect(d).To(BeNumerically("<=", 10*time.Millisecond))
+
+				if d < 3*time.Second {
+					// run the test repeatedly until a value less than the
+					// fundamental value is returned.
+					return
+				}
+			}
+
+			Fail("exhausted attempts to detect jitter")
+		})
+
+		It("respects the lower bound", func() {
+			backoff.Min = 25 * time.Millisecond
+
+			Expect(backoff.Fail(nil)).To(Equal(25 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(25 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(30 * time.Millisecond))
+		})
+
+		It("respects the upper bound", func() {
+			backoff.Max = 15 * time.Millisecond
+
+			Expect(backoff.Fail(nil)).To(Equal(10 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(15 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(15 * time.Millisecond))
+		})
+
+		It("uses a default upper bound of one hour", func() {
+			backoff.Strategy = LinearBackoff(25 * time.Minute)
+
+			Expect(backoff.Fail(nil)).To(Equal(25 * time.Minute))
+			Expect(backoff.Fail(nil)).To(Equal(50 * time.Minute))
+			Expect(backoff.Fail(nil)).To(Equal(1 * time.Hour))
+		})
+
+		It("checks the lower bound after the transform", func() {
+			backoff.Min = 25 * time.Millisecond
+			backoff.Transform = func(d time.Duration) time.Duration {
+				return d * 2
+			}
+
+			Expect(backoff.Fail(nil)).To(Equal(25 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(40 * time.Millisecond))
+		})
+
+		It("checks the upper bound after the transform", func() {
+			backoff.Max = 25 * time.Millisecond
+			backoff.Transform = func(d time.Duration) time.Duration {
+				return d * 2
+			}
+
+			Expect(backoff.Fail(nil)).To(Equal(20 * time.Millisecond))
+			Expect(backoff.Fail(nil)).To(Equal(25 * time.Millisecond))
+		})
+	})
+
+	Describe("func Sleep()", func() {
+		It("sleeps for the computed wait duration", func() {
+			start := time.Now()
+			err := backoff.Sleep(context.Background(), nil)
+			stop := time.Now()
+			elapsed := stop.Sub(start)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(elapsed).To(BeNumerically(">=", 10*time.Millisecond))
+		})
+	})
+})
+
+var _ = Describe("func ExponentialBackoff()", func() {
+	It("returns a strategy that backs-off exponentially", func() {
+		strategy := ExponentialBackoff(3 * time.Second)
+
+		Expect(strategy(5, nil)).To(Equal(48 * time.Second))
+		Expect(strategy(6, nil)).To(Equal(96 * time.Second))
+	})
+
+	It("panics if the unit is zero", func() {
+		Expect(func() {
+			ExponentialBackoff(0)
+		}).To(Panic())
+	})
+
+	It("panics if the unit is negative", func() {
+		Expect(func() {
+			ExponentialBackoff(-1)
+		}).To(Panic())
+	})
+})
+
+var _ = Describe("func ConstantBackoff()", func() {
+	It("returns a strategy that returns a fixed duration", func() {
+		strategy := ConstantBackoff(3 * time.Second)
+
+		Expect(strategy(5, nil)).To(Equal(3 * time.Second))
+		Expect(strategy(6, nil)).To(Equal(3 * time.Second))
+	})
+})
+
+var _ = Describe("func LinearBackoff()", func() {
+	It("returns a strategy that returns a fixed duration", func() {
+		strategy := LinearBackoff(3 * time.Second)
+
+		Expect(strategy(5, nil)).To(Equal(15 * time.Second))
+		Expect(strategy(6, nil)).To(Equal(18 * time.Second))
+	})
+})


### PR DESCRIPTION
This PR adds the `Backoff` type, used to implement backoff logic for retry-able operations.

It uses the new `BackoffStrategy` function to compute a "fundamental" delay duration, which can then be transformed using the existing `DurationTransform`, and capped with lower/upper bounds.