### PR TITLE
Separate backoff configuration into its own type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+## Changed
+
+- **[BC]** Move configuration properties from `Backoff` into new `BackoffConfig` struct
+
 ## [0.1.1] - 2020-02-24
 
 ### Added


### PR DESCRIPTION
This commit moves the configurable properties of `Backoff` into a new `BackoffConfig` type that can be shared by multiple `Backoff` instances.