### PR TITLE
Add transform equivalents of predicate and math functions.

### DIFF
--- a/coalesce.go
+++ b/coalesce.go
@@ -30,9 +30,8 @@ func MustCoalesceT(values ...time.Time) time.Time {
 	return MustFirstT(NonZeroT, values...)
 }
 
-// Coalescer returns a DurationTransform that returns the first value positive
-// value. The transform input value is checked first, then each of the given
-// values.
+// Coalescer returns a DurationTransform that returns the first positive value.
+// The transform input value is checked first, then each of the given values.
 //
 // It panics if none of the values are positive.
 func Coalescer(values ...time.Duration) DurationTransform {

--- a/coalesce.go
+++ b/coalesce.go
@@ -29,3 +29,12 @@ func CoalesceT(values ...time.Time) (v time.Time, ok bool) {
 func MustCoalesceT(values ...time.Time) time.Time {
 	return MustFirstT(NonZeroT, values...)
 }
+
+// Coalescer returns a DurationTransform that returns the first value positive
+// value. The transform input value is checked first, then each of the given
+// values.
+//
+// It panics if none of the values are positive.
+func Coalescer(values ...time.Duration) DurationTransform {
+	return Defaulter(Positive, values...)
+}

--- a/coalesce.go
+++ b/coalesce.go
@@ -30,10 +30,11 @@ func MustCoalesceT(values ...time.Time) time.Time {
 	return MustFirstT(NonZeroT, values...)
 }
 
-// Coalescer returns a DurationTransform that returns the first positive value.
-// The transform input value is checked first, then each of the given values.
+// Coalescer returns a DurationTransform that falls back to the first positive
+// value.
 //
-// It panics if none of the values are positive.
+// The transform input value is checked first, then each of the given values in
+// order. It panics if none of the values are positive.
 func Coalescer(values ...time.Duration) DurationTransform {
 	return Defaulter(Positive, values...)
 }

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -23,12 +23,12 @@ var _ = Describe("func Coalesce()", func() {
 })
 
 var _ = Describe("func MustCoalesce()", func() {
-	It("returns the first value that matches the predicate", func() {
+	It("returns the first positive value", func() {
 		v := MustCoalesce(0*time.Second, -1*time.Second, 1*time.Second, 2*time.Second)
 		Expect(v).To(Equal(1 * time.Second))
 	})
 
-	It("panics if no values match", func() {
+	It("panics if no values are positive", func() {
 		Expect(func() {
 			MustCoalesce(0*time.Second, -1*time.Second)
 		}).To(Panic())
@@ -39,13 +39,13 @@ var _ = Describe("func CoalesceT()", func() {
 	epoch := time.Unix(0, 0)
 	now := time.Now()
 
-	It("returns the first value that matches the predicate", func() {
+	It("returns the first non-zero value", func() {
 		v, ok := CoalesceT(time.Time{}, epoch, now)
 		Expect(ok).To(BeTrue())
 		Expect(v).To(BeTemporally("==", epoch))
 	})
 
-	It("returns the zero-value and false if no values match", func() {
+	It("returns the zero-value and false if no values are non-zero", func() {
 		v, ok := CoalesceT(time.Time{})
 		Expect(ok).To(BeFalse())
 		Expect(v).To(Equal(time.Time{}))

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -56,14 +56,32 @@ var _ = Describe("func MustCoalesceT()", func() {
 	epoch := time.Unix(0, 0)
 	now := time.Now()
 
-	It("returns the first value that matches the predicate", func() {
+	It("returns the first non-zero value", func() {
 		v := MustCoalesceT(time.Time{}, epoch, now)
 		Expect(v).To(BeTemporally("==", epoch))
 	})
 
-	It("panics if no values match", func() {
+	It("panics if no values are non-zero", func() {
 		Expect(func() {
 			MustCoalesceT(time.Time{})
+		}).To(Panic())
+	})
+})
+
+var _ = Describe("func Coalescer()", func() {
+	It("returns the first positive value", func() {
+		v := Coalescer(-1*time.Second, 1*time.Second)(0 * time.Second)
+		Expect(v).To(Equal(1 * time.Second))
+	})
+
+	It("returns the input value if it is positive", func() {
+		v := Coalescer(-1*time.Second, 1*time.Second)(5 * time.Second)
+		Expect(v).To(Equal(5 * time.Second))
+	})
+
+	It("panics if no values are positive", func() {
+		Expect(func() {
+			Coalescer(-1 * time.Second)(0 * time.Second)
 		}).To(Panic())
 	})
 })

--- a/first.go
+++ b/first.go
@@ -54,11 +54,11 @@ func MustFirstT(p TimePredicate, values ...time.Time) time.Time {
 	panic("the predicate did not match any input values")
 }
 
-// Defaulter returns a DurationTransform that returns the first value for which
-// the predicate function p returns true. The transform input value is checked
-// first, then each of the given values.
+// Defaulter returns a DurationTransform that falls back to the first value for
+// which the predicate function p returns true.
 //
-// It panics if p returns false for all values.
+// The transform input value is checked first, then each of the given values in
+// order. It panics if p returns false for all values.
 func Defaulter(p DurationPredicate, values ...time.Duration) DurationTransform {
 	return func(v time.Duration) time.Duration {
 		if p(v) {

--- a/first.go
+++ b/first.go
@@ -53,3 +53,18 @@ func MustFirstT(p TimePredicate, values ...time.Time) time.Time {
 
 	panic("the predicate did not match any input values")
 }
+
+// Defaulter returns a DurationTransform that returns the first value for which
+// the predicate function p returns true. The transform input value is checked
+// first, then each of the given values.
+//
+// It panics if p returns false for all values.
+func Defaulter(p DurationPredicate, values ...time.Duration) DurationTransform {
+	return func(v time.Duration) time.Duration {
+		if p(v) {
+			return v
+		}
+
+		return MustFirst(p, values...)
+	}
+}

--- a/first_test.go
+++ b/first_test.go
@@ -65,3 +65,21 @@ var _ = Describe("func MustFirstT()", func() {
 		}).To(Panic())
 	})
 })
+
+var _ = Describe("func Defaulter()", func() {
+	It("returns the first value that matches the predicate", func() {
+		v := Defaulter(Positive, -1*time.Second, 1*time.Second)(0 * time.Second)
+		Expect(v).To(Equal(1 * time.Second))
+	})
+
+	It("returns the input value if it matches the predicate", func() {
+		v := Defaulter(Positive, -1*time.Second, 1*time.Second)(5 * time.Second)
+		Expect(v).To(Equal(5 * time.Second))
+	})
+
+	It("panics if no values match", func() {
+		Expect(func() {
+			Defaulter(Positive, -1*time.Second)(0 * time.Second)
+		}).To(Panic())
+	})
+})

--- a/math.go
+++ b/math.go
@@ -20,9 +20,23 @@ func Multiply(d time.Duration, v float64) time.Duration {
 	return FromSeconds(d.Seconds() * v)
 }
 
+// Multiplier returns a DurationTransform that multiplies the input duration by v.
+func Multiplier(v float64) DurationTransform {
+	return func(d time.Duration) time.Duration {
+		return Multiply(d, v)
+	}
+}
+
 // Divide returns the result of dividing d by v.
 func Divide(d time.Duration, v float64) time.Duration {
 	return FromSeconds(d.Seconds() / v)
+}
+
+// Divider returns a DurationTransform that divides the input duration by v.
+func Divider(v float64) DurationTransform {
+	return func(d time.Duration) time.Duration {
+		return Divide(d, v)
+	}
 }
 
 // Shortest returns the smallest of the given durations.
@@ -100,6 +114,14 @@ func Limit(d, a, b time.Duration) time.Duration {
 	}
 
 	return d
+}
+
+// Limiter returns a DurationTransform that limits the input duration
+// between a and b, inclusive.
+func Limiter(a, b time.Duration) DurationTransform {
+	return func(d time.Duration) time.Duration {
+		return Limit(d, a, b)
+	}
 }
 
 // LimitT returns the time t, capped between a and b, inclusive.

--- a/math_test.go
+++ b/math_test.go
@@ -16,9 +16,23 @@ var _ = Describe("func Multiply()", func() {
 	})
 })
 
+var _ = Describe("func Multiplier()", func() {
+	It("multiplies the input duration", func() {
+		d := Multiplier(1.5)(10 * time.Second)
+		Expect(d).To(Equal(15 * time.Second))
+	})
+})
+
 var _ = Describe("func Divide()", func() {
 	It("returns the expected quotient", func() {
 		d := Divide(15*time.Second, 1.5)
+		Expect(d).To(Equal(10 * time.Second))
+	})
+})
+
+var _ = Describe("func Divider()", func() {
+	It("divides the input duration", func() {
+		d := Divider(1.5)(15 * time.Second)
 		Expect(d).To(Equal(10 * time.Second))
 	})
 })
@@ -88,6 +102,20 @@ var _ = DescribeTable(
 		b := 30 * time.Second
 		Expect(Limit(in, a, b)).To(Equal(out))
 		Expect(Limit(in, b, a)).To(Equal(out))
+	},
+	Entry("limit to min", 15*time.Second, 20*time.Second),
+	Entry("limit to max", 35*time.Second, 30*time.Second),
+	Entry("do not limit", 25*time.Second, 25*time.Second),
+)
+
+var _ = DescribeTable(
+	"func Limiter()",
+	func(in, out time.Duration) {
+		a := 20 * time.Second
+		b := 30 * time.Second
+		x := Limiter(a, b)
+		Expect(x(in)).To(Equal(out))
+		Expect(x(in)).To(Equal(out))
 	},
 	Entry("limit to min", 15*time.Second, 20*time.Second),
 	Entry("limit to max", 35*time.Second, 30*time.Second),


### PR DESCRIPTION
This PR adds several new `DurationTransform` implementations that are equivalent to existing convenience functions:

- `Coalescer` is the transform equivalent to `MustCoalesce()`
- `Defaulter` is the transform equivalent to `MustFirst()`
- `Multiplier` is the transform equivalent to `Multiply()`
- `Divider` is the transform equivalent to `Divide()`
- `Limiter` is the transform equivalent to `Limit()`