### PR TITLE
Protect backoff strategies from overflowing `time.Duration`.

### DIFF
--- a/backoff/strategy.go
+++ b/backoff/strategy.go
@@ -70,7 +70,7 @@ func Linear(unit time.Duration) Strategy {
 		delay := mult * unit
 
 		// Overflow check: If delay is negative, there was clearly an overflow
-		// because both n and mult are positive.
+		// because both unit and mult are positive.
 		if delay < 0 {
 			return linger.MaxDuration
 		}

--- a/backoff/strategy.go
+++ b/backoff/strategy.go
@@ -35,12 +35,18 @@ func Exponential(unit time.Duration) Strategy {
 		panic("the unit duration must be postive")
 	}
 
-	u := unit.Seconds()
+	u := float64(unit)
 
 	return func(_ error, n uint) time.Duration {
 		scale := math.Pow(2, float64(n))
-		seconds := u * scale
-		return linger.FromSeconds(seconds)
+		nanos := u * scale
+
+		// Overflow check.
+		if nanos >= float64(linger.MaxDuration) {
+			return linger.MaxDuration
+		}
+
+		return time.Duration(nanos)
 	}
 }
 
@@ -55,8 +61,27 @@ func Constant(d time.Duration) Strategy {
 //
 // The unit delay is multiplied by the number of successive failures.
 func Linear(unit time.Duration) Strategy {
+	if unit <= 0 {
+		panic("the unit duration must be postive")
+	}
+
 	return func(_ error, n uint) time.Duration {
-		return time.Duration(n+1) * unit
+		mult := time.Duration(n) + 1
+		delay := mult * unit
+
+		// Overflow check: If delay is negative, there was clearly an overflow
+		// because both n and mult are positive.
+		if delay < 0 {
+			return linger.MaxDuration
+		}
+
+		// Overflow check: Dividing the delay by the unit value should give us
+		// back the multiplier that we used. If not, there was an overflow.
+		if delay/unit != mult {
+			return linger.MaxDuration
+		}
+
+		return delay
 	}
 }
 

--- a/backoff/strategy_test.go
+++ b/backoff/strategy_test.go
@@ -28,6 +28,15 @@ var _ = Describe("func Exponential()", func() {
 			Exponential(-1)
 		}).To(Panic())
 	})
+
+	It("does not overflow the time.Duration type", func() {
+		strategy := Exponential(1)
+
+		Expect(strategy(nil, 62)).To(Equal(time.Duration(4611686018427387904)))
+		Expect(strategy(nil, 63)).To(Equal(linger.MaxDuration))
+		Expect(strategy(nil, 100)).To(Equal(linger.MaxDuration))
+	})
+
 })
 
 var _ = Describe("func Constant()", func() {
@@ -45,6 +54,28 @@ var _ = Describe("func Linear()", func() {
 
 		Expect(strategy(nil, 4)).To(Equal(15 * time.Second))
 		Expect(strategy(nil, 5)).To(Equal(18 * time.Second))
+	})
+
+	It("panics if the unit is zero", func() {
+		Expect(func() {
+			Linear(0)
+		}).To(Panic())
+	})
+
+	It("panics if the unit is negative", func() {
+		Expect(func() {
+			Linear(-1)
+		}).To(Panic())
+	})
+
+	It("does not overflow the time.Duration type", func() {
+		strategy := Linear(linger.MaxDuration / 2)
+
+		Expect(strategy(nil, 0)).To(Equal(linger.MaxDuration / 2))
+		Expect(strategy(nil, 1)).To(Equal(linger.MaxDuration - 1))
+		Expect(strategy(nil, 2)).To(Equal(linger.MaxDuration))
+		Expect(strategy(nil, 3)).To(Equal(linger.MaxDuration))
+		Expect(strategy(nil, 4)).To(Equal(linger.MaxDuration))
 	})
 })
 


### PR DESCRIPTION
Fixes #16 