### PR TITLE
If applied, this PR will introduce funcs FirstStrategy and CoalesceStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased] - 2023-01-16
+
+### Added
+
+- Add `FirstStrategy` and `CoalesceStrategy`
+
 ## [1.0.0] - 2022-11-29
 
 ### Changed

--- a/backoff/strategy.go
+++ b/backoff/strategy.go
@@ -98,3 +98,24 @@ func WithTransforms(s Strategy, transforms ...linger.DurationTransform) Strategy
 		return d
 	}
 }
+
+// CoalesceStrategy returns a strategy that iterates over the given strategies
+// and runs them, returning the first positive duration.
+func CoalesceStrategy(strategies ...Strategy) Strategy {
+	return FirstStrategy(linger.Positive, strategies...)
+}
+
+// FirstStrategy returns a strategy that iterates over the given strategies
+// and runs them, returning the first duration which satisfies the predicate.
+// Return zero if no duration satisfies the predicate.
+func FirstStrategy(p linger.DurationPredicate, strategies ...Strategy) Strategy {
+	return func(e error, n uint) time.Duration {
+		for _, s := range strategies {
+			d := s(e, n)
+			if p(d) {
+				return d
+			}
+		}
+		return 0
+	}
+}

--- a/backoff/strategy_test.go
+++ b/backoff/strategy_test.go
@@ -108,3 +108,41 @@ var _ = Describe("func WithTransform()", func() {
 		Expect(s(nil, 2)).To(Equal(25 * time.Second))
 	})
 })
+
+var _ = Describe("func CoalesceStrategy()", func() {
+	It("returns a strategy that yields the first positive duration", func() {
+
+		stgyOne := func(_ error, n uint) time.Duration {
+			if n == 1 {
+				return 6 * time.Second
+			}
+			return 0
+		}
+
+		stgyTwo := func(_ error, n uint) time.Duration {
+			if n == 2 {
+				return 9 * time.Second
+			}
+			return 0
+		}
+
+		s := CoalesceStrategy(
+			stgyOne,
+			stgyTwo,
+		)
+
+		sC := CoalesceStrategy(
+			s,
+			Constant(3*time.Second),
+		)
+
+		Expect(s(nil, 0)).To(Equal(0 * time.Second))
+		Expect(s(nil, 1)).To(Equal(6 * time.Second))
+		Expect(s(nil, 2)).To(Equal(9 * time.Second))
+
+		Expect(sC(nil, 0)).To(Equal(3 * time.Second))
+		Expect(sC(nil, 1)).To(Equal(6 * time.Second))
+		Expect(sC(nil, 2)).To(Equal(9 * time.Second))
+
+	})
+})


### PR DESCRIPTION
#### What change does this introduce?

adding new funcs `FirstStrategy` and `CoalesceStrategy`

#### Why make this change?

Allow users to compose strategies together without having to implement a custom strategy func to do so. For example, I would like to have a strategy which attempts to extract time.Duration from the error metadata, but default to a strategy of my choice if it's not found. With this change, I can implement it as below:
```
var GrpcErrOrExponential = CoalesceStrategy(
	GrpcErrStrategy,
	Exponential(3*time.Second),
)

var GrpcErrOrLinear = CoalesceStrategy(
	GrpcErrStrategy,
	Linear(3*time.Second),
)
```

#### Is there anything you are unsure about?

...

#### What issues does this relate to?

fixes [#68](https://github.com/dogmatiq/linger/issues/68)
